### PR TITLE
Feat: 멤버 회원가입시 ID, 닉네임 중복확인, 튜터 전체 조회 기능

### DIFF
--- a/src/main/kotlin/com/sparta/tfbq/domain/member/controller/MemberController.kt
+++ b/src/main/kotlin/com/sparta/tfbq/domain/member/controller/MemberController.kt
@@ -1,0 +1,37 @@
+package com.sparta.tfbq.domain.member.controller
+
+import com.sparta.tfbq.domain.member.dto.response.MemberResponse
+import com.sparta.tfbq.domain.member.service.MemberService
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/members")
+class MemberController (
+    private val memberService: MemberService
+) {
+
+    @GetMapping("/check")
+     fun checkEmail(@RequestParam("email") email: String): ResponseEntity<Unit> {
+        memberService.checkEmail(email)
+        return ResponseEntity.ok().build()
+     }
+
+    @GetMapping("/check")
+    fun checkNickname (@RequestParam("nickname") nickname: String): ResponseEntity<Unit>{
+        memberService.checkNickname(nickname)
+        return ResponseEntity.ok().build()
+    }
+
+    @GetMapping("/tutors")
+    fun findTutors (): ResponseEntity<List<MemberResponse>>{
+          return ResponseEntity
+              .status(HttpStatus.OK)
+              .body(memberService.findTutors())
+    }
+
+}

--- a/src/main/kotlin/com/sparta/tfbq/domain/member/controller/MemberController.kt
+++ b/src/main/kotlin/com/sparta/tfbq/domain/member/controller/MemberController.kt
@@ -28,7 +28,7 @@ class MemberController (
     }
 
     @GetMapping("/tutors")
-    fun findTutors (): ResponseEntity<List<MemberResponse>>{
+    fun findTutors(): ResponseEntity<List<MemberResponse>>{
           return ResponseEntity
               .status(HttpStatus.OK)
               .body(memberService.findTutors())

--- a/src/main/kotlin/com/sparta/tfbq/domain/member/dto/response/MemberResponse.kt
+++ b/src/main/kotlin/com/sparta/tfbq/domain/member/dto/response/MemberResponse.kt
@@ -1,0 +1,23 @@
+package com.sparta.tfbq.domain.member.dto.response
+
+import com.sparta.tfbq.domain.member.model.Member
+
+data class MemberResponse(
+    val id: Long,
+    val email: String,
+    val name: String,
+    val nickname: String,
+    val role: String,
+) {
+    companion object {
+        fun from(member: Member): MemberResponse {
+            return MemberResponse(
+                member.id!!,
+                member.email,
+                member.name,
+                member.nickname,
+                member.role.name
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/sparta/tfbq/domain/member/repository/MemberRepository.kt
+++ b/src/main/kotlin/com/sparta/tfbq/domain/member/repository/MemberRepository.kt
@@ -6,4 +6,5 @@ import org.springframework.stereotype.Repository
 
 @Repository
 interface MemberRepository : JpaRepository<Member, Long> {
-}
+    fun existsByEmail(email: String): Boolean
+    fun existsByNickname(nickname: String): Boolean }

--- a/src/main/kotlin/com/sparta/tfbq/domain/member/repository/MemberRepository.kt
+++ b/src/main/kotlin/com/sparta/tfbq/domain/member/repository/MemberRepository.kt
@@ -7,4 +7,5 @@ import org.springframework.stereotype.Repository
 @Repository
 interface MemberRepository : JpaRepository<Member, Long> {
     fun existsByEmail(email: String): Boolean
-    fun existsByNickname(nickname: String): Boolean }
+    fun existsByNickname(nickname: String): Boolean
+}

--- a/src/main/kotlin/com/sparta/tfbq/domain/member/service/MemberService.kt
+++ b/src/main/kotlin/com/sparta/tfbq/domain/member/service/MemberService.kt
@@ -1,0 +1,30 @@
+package com.sparta.tfbq.domain.member.service
+
+import com.sparta.tfbq.domain.member.dto.response.MemberResponse
+import com.sparta.tfbq.domain.member.repository.MemberRepository
+import jakarta.transaction.Transactional
+import org.springframework.stereotype.Service
+
+
+@Service
+class MemberService(
+    private val memberRepository: MemberRepository
+) {
+    @Transactional
+    fun checkEmail(email: String) {
+        val isDuplicate = memberRepository.existsByEmail(email)
+        if (isDuplicate) throw DuplicateValueException("email 중복됩니다.")
+    }
+    @Transactional
+    fun checkNickname(nickname: String){
+        val isDuplicate = memberRepository.existsByNickname(nickname)
+        if (isDuplicate) throw DuplicatedValueException("nickname 중복됩니다.")
+    }
+
+    @Transactional
+    fun findTutors() : List<MemberResponse> {
+        val memberList = memberRepository.findAll().map { MemberResponse.from(it) }
+            .filter { it.role == "TUTOR" }
+        return memberList
+    }
+}

--- a/src/main/kotlin/com/sparta/tfbq/domain/member/service/MemberService.kt
+++ b/src/main/kotlin/com/sparta/tfbq/domain/member/service/MemberService.kt
@@ -1,6 +1,7 @@
 package com.sparta.tfbq.domain.member.service
 
 import com.sparta.tfbq.domain.member.dto.response.MemberResponse
+import com.sparta.tfbq.domain.member.model.MemberRole
 import com.sparta.tfbq.domain.member.repository.MemberRepository
 import jakarta.transaction.Transactional
 import org.springframework.stereotype.Service
@@ -23,8 +24,9 @@ class MemberService(
 
     @Transactional
     fun findTutors() : List<MemberResponse> {
-        val memberList = memberRepository.findAll().map { MemberResponse.from(it) }
-            .filter { it.role == "TUTOR" }
+        val memberList = memberRepository.findAll().filter { it.role == MemberRole.TUTOR }
+            .map { MemberResponse.from(it) }
+
         return memberList
     }
 }


### PR DESCRIPTION
- MemberController: 회원가입시 이메일,닉네임 중복확인, 튜터 전체조회 기능
- MemberResponse:멤버 정보 응답내용, Member Response 변화코드
- MemberRepository: 이메일, 닉네임 중복체크 Boolean 값
- MemberService: 이메일, 닉네임 중복체크, 튜터전체조회(필터-역할이 튜터일 경우 자료 반환)

## 연관 이슈
- closes #9  

## 해당 작업을 한 동기는 무엇인가요?
-멤버 회원가입시 이메일, 닉네임 중복 확인, 전체튜터조회 기능입니다.

## 리뷰어에게 작업 또는 변경 내용을 가능한 상세히 설명해주세요
- [ ] member response를 바꿔서 컨트롤러에 적용한 코드가 맞는지 봐주세요.