### PR TITLE
Feat: 멤버 엔티티 관련 기능 추가 및 수정

### DIFF
--- a/src/main/kotlin/com/sparta/tfbq/domain/member/controller/MemberController.kt
+++ b/src/main/kotlin/com/sparta/tfbq/domain/member/controller/MemberController.kt
@@ -1,42 +1,53 @@
 package com.sparta.tfbq.domain.member.controller
 
+import com.sparta.tfbq.domain.member.dto.request.MemberCreateRequest
 import com.sparta.tfbq.domain.member.dto.response.MemberResponse
-import com.sparta.tfbq.domain.member.dto.response.TutorInfoResponse
 import com.sparta.tfbq.domain.member.service.MemberService
+import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
+import java.net.URI
 
 @RestController
 @RequestMapping("/api/v1/members")
-class MemberController (
+class MemberController(
     private val memberService: MemberService
 ) {
+    // C
+    @PostMapping
+    fun signUp(@RequestBody @Valid request: MemberCreateRequest): ResponseEntity<Unit> {
+        val memberId = memberService.signUp(request)
+        return ResponseEntity.created(URI.create(String.format("/api/v1/members/%d", memberId))).build()
+    }
 
+    // R
     @GetMapping("/check")
-     fun checkEmail(@RequestParam("email") email: String): ResponseEntity<Unit> {
-        memberService.checkEmail(email)
-        return ResponseEntity.ok().build()
-     }
-
-    @GetMapping("/check")
-    fun checkNickname (@RequestParam("nickname") nickname: String): ResponseEntity<Unit>{
-        memberService.checkNickname(nickname)
+    fun checkDuplicate(@RequestParam("value") value: String): ResponseEntity<Unit> {
+        memberService.checkDuplicate(value)
         return ResponseEntity.ok().build()
     }
 
     @GetMapping("/tutors")
-    fun findTutors(): ResponseEntity<List<MemberResponse>>{
-          return ResponseEntity
-              .status(HttpStatus.OK)
-              .body(memberService.findTutors())
+    fun findTutors(): ResponseEntity<List<MemberResponse>> {
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(memberService.findTutors())
     }
 
-    @GetMapping("/{tutorId}")
-    fun findTutorInfo(@PathVariable tutorId: Long): ResponseEntity<TutorInfoResponse> {
-        val response: TutorInfoResponse = memberService.findTutorInfo(tutorId)
-
+    @GetMapping("/{memberId}")
+    fun findMember(@PathVariable memberId: Long): ResponseEntity<MemberResponse> {
+        val response = memberService.findMember(memberId)
         return ResponseEntity.ok(response)
+    }
+
+    // U
+
+    // D
+    @DeleteMapping("/{memberId}")
+    fun withdrawal(@PathVariable memberId: Long): ResponseEntity<Unit> {
+        memberService.withdrawal(memberId)
+        return ResponseEntity.noContent().build()
     }
 
 }

--- a/src/main/kotlin/com/sparta/tfbq/domain/member/dto/request/MemberCreateRequest.kt
+++ b/src/main/kotlin/com/sparta/tfbq/domain/member/dto/request/MemberCreateRequest.kt
@@ -1,0 +1,38 @@
+package com.sparta.tfbq.domain.member.dto.request
+
+import com.sparta.tfbq.domain.member.model.Member
+import com.sparta.tfbq.domain.member.model.MemberRole
+import jakarta.validation.constraints.Email
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Pattern
+
+data class MemberCreateRequest(
+    @field:Email(message = "올바른 이메일 형식을 입력해주세요")
+    @field:NotBlank(message = "이메일은 필수입력 사항입니다")
+    val email: String,
+
+    @field:NotBlank(message = "이름은 필수입력 사항입니다")
+    val name: String,
+
+    @field:Pattern(
+        regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)[a-zA-Z\\d]{8,}${'$'}",
+        message = "비밀번호는 영문과 특수문자 숫자를 포함하며 8자 이상이어야 합니다"
+    )
+    val password: String,
+
+    @field:NotBlank(message = "역할은 필수입력 사항입니다")
+    val role: MemberRole,
+
+    val nickname: String?,
+) {
+
+    fun toEntity() =
+        Member(
+            email = email,
+            name = name,
+            password = password,
+            memberRole = role,
+            nickname = nickname
+        )
+
+}

--- a/src/main/kotlin/com/sparta/tfbq/domain/member/dto/response/MemberResponse.kt
+++ b/src/main/kotlin/com/sparta/tfbq/domain/member/dto/response/MemberResponse.kt
@@ -1,23 +1,26 @@
 package com.sparta.tfbq.domain.member.dto.response
 
 import com.sparta.tfbq.domain.member.model.Member
+import com.sparta.tfbq.domain.question.dto.response.QuestionResponse
 
-data class MemberResponse(
-    val id: Long,
-    val email: String,
-    val name: String,
-    val nickname: String,
-    val role: String,
+open class MemberResponse(
+    open val email: String,
+    open val name: String,
 ) {
     companion object {
-        fun from(member: Member): MemberResponse {
-            return MemberResponse(
-                member.id!!,
-                member.email,
-                member.name,
-                member.nickname,
-                member.role.name
+        fun from(member: Member) =
+            StudentInfoResponse(
+                email = member.email,
+                name = member.name,
+                nickname = member.nickname!!
             )
-        }
+
+        fun from(member: Member, questions: List<QuestionResponse>) =
+            TutorInfoResponse(
+                email = member.email,
+                name = member.name,
+                questions = questions
+            )
     }
+
 }

--- a/src/main/kotlin/com/sparta/tfbq/domain/member/dto/response/StudentInfoResponse.kt
+++ b/src/main/kotlin/com/sparta/tfbq/domain/member/dto/response/StudentInfoResponse.kt
@@ -1,0 +1,7 @@
+package com.sparta.tfbq.domain.member.dto.response
+
+data class StudentInfoResponse(
+    override val email: String,
+    override val name: String,
+    val nickname: String
+) : MemberResponse(email, name)

--- a/src/main/kotlin/com/sparta/tfbq/domain/member/dto/response/TutorInfoResponse.kt
+++ b/src/main/kotlin/com/sparta/tfbq/domain/member/dto/response/TutorInfoResponse.kt
@@ -1,22 +1,9 @@
 package com.sparta.tfbq.domain.member.dto.response
 
-import com.sparta.tfbq.domain.member.model.Member
 import com.sparta.tfbq.domain.question.dto.response.QuestionResponse
 
-
-
 data class TutorInfoResponse(
-    val name: String,
-    val email: String,
+    override val email: String,
+    override val name: String,
     val questions: List<QuestionResponse>
-) {
-    companion object {
-        fun from(member: Member, questions: List<QuestionResponse>): TutorInfoResponse {
-            return TutorInfoResponse(
-                name = member.name,
-                email = member.email,
-                questions = questions
-            )
-        }
-    }
-}
+): MemberResponse(email, name)

--- a/src/main/kotlin/com/sparta/tfbq/domain/member/exception/UnauthorizedValueException.kt
+++ b/src/main/kotlin/com/sparta/tfbq/domain/member/exception/UnauthorizedValueException.kt
@@ -1,0 +1,3 @@
+package com.sparta.tfbq.domain.member.exception
+
+class UnauthorizedValueException(message: String) : RuntimeException(message)

--- a/src/main/kotlin/com/sparta/tfbq/domain/member/model/MemberRole.kt
+++ b/src/main/kotlin/com/sparta/tfbq/domain/member/model/MemberRole.kt
@@ -1,6 +1,22 @@
 package com.sparta.tfbq.domain.member.model
 
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.sparta.tfbq.global.exception.ModelNotFoundException
+
 enum class MemberRole {
     STUDENT,
-    TUTOR
+    TUTOR;
+
+    companion object {
+        @JsonCreator
+        fun of(role: String): MemberRole {
+            return MemberRole.values().firstOrNull { role.uppercase() == it.name }
+                ?: throw ModelNotFoundException("Role")
+        }
+
+        fun isTutor(role: MemberRole) = role == TUTOR
+
+        fun isStudent(role: MemberRole) = role == STUDENT
+
+    }
 }

--- a/src/main/kotlin/com/sparta/tfbq/domain/member/service/MemberService.kt
+++ b/src/main/kotlin/com/sparta/tfbq/domain/member/service/MemberService.kt
@@ -1,44 +1,63 @@
 package com.sparta.tfbq.domain.member.service
 
+import com.sparta.tfbq.domain.member.dto.request.MemberCreateRequest
 import com.sparta.tfbq.domain.member.dto.response.MemberResponse
-import com.sparta.tfbq.domain.member.dto.response.TutorInfoResponse
-import com.sparta.tfbq.domain.member.model.Member
-import com.sparta.tfbq.domain.member.model.MemberRole
+import com.sparta.tfbq.domain.member.exception.UnauthorizedValueException
+import com.sparta.tfbq.domain.member.model.MemberRole.Companion.isTutor
 import com.sparta.tfbq.domain.member.repository.MemberRepository
-import com.sparta.tfbq.global.exception.DuplicatedValueException
 import com.sparta.tfbq.domain.question.dto.response.QuestionResponse
+import com.sparta.tfbq.global.exception.DuplicatedValueException
+import com.sparta.tfbq.global.exception.ModelNotFoundException
 import jakarta.transaction.Transactional
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
-
 
 @Service
 class MemberService(
     private val memberRepository: MemberRepository
 ) {
     @Transactional
-    fun checkEmail(email: String) {
-        val isDuplicate = memberRepository.existsByEmail(email)
-        if (isDuplicate) throw DuplicatedValueException("email")
-    }
-    @Transactional
-    fun checkNickname(nickname: String){
-        val isDuplicate = memberRepository.existsByNickname(nickname)
-        if (isDuplicate) throw DuplicatedValueException("nickname")
+    fun signUp(request: MemberCreateRequest): Long {
+        if (isTutor(request.role) && request.nickname?.length!! > 0) {
+            throw UnauthorizedValueException("튜터는 닉네임을 사용할 수 없습니다")
+        }
+        val member = memberRepository.save(request.toEntity())
+        return member.id!!
     }
 
     @Transactional
-    fun findTutors() : List<MemberResponse> {
-        val memberList = memberRepository.findAll().filter { it.role == MemberRole.TUTOR }
+    fun checkDuplicate(value: String) {
+        val isDuplicate = when (value.contains("@")) {
+            true -> memberRepository.existsByEmail(value)
+            false -> memberRepository.existsByNickname(value)
+        }
+        if (isDuplicate) throw DuplicatedValueException(value)
+    }
+
+    @Transactional
+    fun findTutors(): List<MemberResponse> {
+        return memberRepository.findAll().filter { isTutor(it.role) }
             .map { MemberResponse.from(it) }
-
-        return memberList
     }
 
-    fun findTutorInfo(tutorId: Long): TutorInfoResponse {
-        val member: Member = memberRepository.findByIdOrNull(tutorId) ?: throw Exception()
-        val questions = member.questions.map { QuestionResponse.from(it) }
+    fun findMember(memberId: Long): MemberResponse {
+        val member = getMemberById(memberId)
 
-        return TutorInfoResponse.from(member, questions)
+        return when (isTutor(member.role)) {
+            true -> {
+                val questions = member.questions.map { QuestionResponse.from(it) }
+                MemberResponse.from(member, questions)
+            }
+
+            false -> MemberResponse.from(member)
+        }
     }
+
+    fun withdrawal(memberId: Long) {
+        val member = getMemberById(memberId)
+        memberRepository.delete(member)
+    }
+
+    fun getMemberById(memberId: Long) =
+        memberRepository.findByIdOrNull(memberId) ?: throw ModelNotFoundException("Member")
 }

--- a/src/main/kotlin/com/sparta/tfbq/global/util/PasswordEncoder.kt
+++ b/src/main/kotlin/com/sparta/tfbq/global/util/PasswordEncoder.kt
@@ -1,0 +1,14 @@
+package com.sparta.tfbq.global.util
+
+import java.util.Base64
+
+class PasswordEncoder {
+    companion object {
+
+        fun encode(password: String) = Base64.getEncoder().encodeToString(password.toByteArray())!!
+
+        fun decode(encodedPassword: String) = Base64.getEncoder()
+            .encodeToString(encodedPassword.toByteArray())!!
+
+    }
+}

--- a/src/main/kotlin/com/sparta/tfbq/global/util/RandomNicknameGenerator.kt
+++ b/src/main/kotlin/com/sparta/tfbq/global/util/RandomNicknameGenerator.kt
@@ -1,0 +1,10 @@
+package com.sparta.tfbq.global.util
+
+
+class RandomNicknameGenerator {
+    companion object {
+        private val wordList = ('0'..'9') + ('a'..'z') + ('A'..'Z')
+
+        fun generateRandomNickname() = List(20) { wordList.random() }.joinToString(prefix = "익명의 회원", separator = "")
+    }
+}


### PR DESCRIPTION
## 연관 이슈
- closes #23 

## 해당 작업을 한 동기는 무엇인가요?
기존 멤버와 관련된 기능을 수정하거나, 새로운 기능에 대한 구현을 위해 작업하였습니다.

## 리뷰어에게 작업 또는 변경 내용을 가능한 상세히 설명해주세요
- [x] 멤버 컨트롤러 및 서비스 관련
  - 기존 멤버 컨트롤러에서 이메일 중복 체크 API와 닉네임 중복 체크 API를 하나의 중복 체크 API로 통합하였습니다. 또한 응답 값을 수정하였습니다. 
  - 기존 멤버 서비스에서는 멤버에 대한 조회에 항상 `?: throw ModelNotFoundException`를 던져서 중복되는 코드가 발생했었습니다. 이런 코드를 메서드로 따로 분리하여 변경 전파를 최소화 하였습니다.
  - 또한, 학생, 튜터를 멤버라는 Entity 하나로 관리하기 때문에 멤버와 관련된 서비스에서 멤버 Role에 따라 구분하는 로직이 많은데, 이 Role을 확인하는 역할을 MemberRole에 부여하여 메서드를 생성했습니다.

- [x] 멤버 엔티티 및 DTO 관련
  - 멤버 엔티티 중 unique 처리가 필요한 프로퍼티에 `unique = true`를 추가하였습니다.
  - 멤버 조회시, 학생, 튜터 모두 같은 MemberResponse를 돌려주고 있었습니다. 이를 TutorInfoResponse, StudentInfoResponse로 따로 생성하여 책임을 분리하였습니다. 
  - 비밀번호 암호화를 적용하였습니다. 해당 기능은 Java의 Base64를 사용하였으며, 추후 Spring Security 적용시 변경할 예정입니다.
  - 멤버 중 학생만 닉네임을 설정할 수 있다는 정책에 의해 닉네임을 설정하지 않을 경우, 닉네임을 애플리케이션에서 생성해주는 기능을 구현했습니다.
- [x] 기타 내용
  - 정책 사항이 제대로 수립되지 않아, 전에 정했던 멤버가 삭제되어도 그 질문은 사라지지 않는다는 정책에 따라 멤버 엔티티의 questions의 cascade 처리를 빼고, 서비스의 삭제 메서드에서도 우선은 멤버만 삭제되게끔 적용해놨습니다.
