### PR TITLE
Feat/#25 질문 도메인 관련 클래스 코드 리팩토링

### DIFF
--- a/src/main/kotlin/com/sparta/tfbq/domain/question/controller/QuestionController.kt
+++ b/src/main/kotlin/com/sparta/tfbq/domain/question/controller/QuestionController.kt
@@ -25,8 +25,11 @@ class QuestionController(private val service: QuestionService) {
         return ResponseEntity.ok().build()
     }
 
-    @DeleteMapping("/{memberId}/{questionId}")
-    fun deleteQuestion(@PathVariable memberId: Long, @PathVariable questionId: Long): ResponseEntity<Unit> {
+    @DeleteMapping("/{questionId}/{memberId}")
+    fun deleteQuestion(
+        @PathVariable memberId: Long,
+        @PathVariable questionId: Long
+    ): ResponseEntity<Unit> {
         service.deleteQuestion(memberId, questionId)
         return ResponseEntity.noContent().build()
     }

--- a/src/main/kotlin/com/sparta/tfbq/domain/question/dto/request/UpdateQuestionRequest.kt
+++ b/src/main/kotlin/com/sparta/tfbq/domain/question/dto/request/UpdateQuestionRequest.kt
@@ -2,7 +2,6 @@ package com.sparta.tfbq.domain.question.dto.request
 
 data class UpdateQuestionRequest(
     val memberId: Long,
-    val tutorId: Long,
     val title: String,
     val content: String,
     val isPrivate: Boolean

--- a/src/main/kotlin/com/sparta/tfbq/domain/question/model/Question.kt
+++ b/src/main/kotlin/com/sparta/tfbq/domain/question/model/Question.kt
@@ -3,7 +3,6 @@ package com.sparta.tfbq.domain.question.model
 import com.sparta.tfbq.domain.answer.model.Answer
 import com.sparta.tfbq.domain.member.model.Member
 import com.sparta.tfbq.global.entity.BaseEntity
-import com.sparta.tfbq.global.exception.AlreadyHaveAnswersException
 import jakarta.persistence.*
 
 @Entity

--- a/src/main/kotlin/com/sparta/tfbq/domain/question/model/Question.kt
+++ b/src/main/kotlin/com/sparta/tfbq/domain/question/model/Question.kt
@@ -52,10 +52,6 @@ class Question(
     var isClose = isClose
         private set
 
-    fun availableToUpdate() {
-        if (this.answers.size > 0) throw AlreadyHaveAnswersException()
-    }
-
     fun update(title: String, content: String, isPrivate: Boolean) {
         this.title = title
         this.content = content

--- a/src/main/kotlin/com/sparta/tfbq/domain/question/service/QuestionService.kt
+++ b/src/main/kotlin/com/sparta/tfbq/domain/question/service/QuestionService.kt
@@ -39,8 +39,6 @@ class QuestionService(
         val member = getMember(request.memberId)
         val question = getQuestion(questionId)
 
-        // 질문 대상(튜터)을 옳게 설정했는지 확인
-        validateAvailableTutor(request.tutorId)
         // 질문 수정은 학생만 할 수 있다
         validateRole(member.role)
         // 질문에 답변이 1개 이상 존재하는 경우, 학생은 질문을 수정할 수 없다
@@ -57,14 +55,6 @@ class QuestionService(
     fun deleteQuestion(memberId: Long, questionId: Long) {
         val member = getMember(memberId)
         val question = getQuestion(questionId)
-
-        /*
-        memberId로 member를 가져오면?
-        '삭제' 버튼을 누른 사람
-
-        questionId->question->member->id로 member를 가져오면?
-        질문 등록한 사람
-         */
 
         // 질문 삭제는 학생만 할 수 있다
         validateRole(member.role)

--- a/src/main/kotlin/com/sparta/tfbq/domain/question/service/QuestionService.kt
+++ b/src/main/kotlin/com/sparta/tfbq/domain/question/service/QuestionService.kt
@@ -1,10 +1,14 @@
 package com.sparta.tfbq.domain.question.service
 
+import com.sparta.tfbq.domain.member.model.MemberRole
 import com.sparta.tfbq.domain.member.repository.MemberRepository
 import com.sparta.tfbq.domain.question.dto.request.AddQuestionRequest
 import com.sparta.tfbq.domain.question.dto.request.UpdateQuestionRequest
+import com.sparta.tfbq.domain.question.model.Question
 import com.sparta.tfbq.domain.question.repository.QuestionRepository
+import com.sparta.tfbq.global.exception.AlreadyHaveAnswersException
 import com.sparta.tfbq.global.exception.ModelNotFoundException
+import com.sparta.tfbq.global.exception.WrongRoleException
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -16,12 +20,12 @@ class QuestionService(
 ) {
     @Transactional
     fun addQuestion(request: AddQuestionRequest): Long {
-        val member = memberRepository.findByIdOrNull(request.memberId)
-            ?: throw ModelNotFoundException("Member")
-        if (!memberRepository.existsById(request.tutorId)) throw ModelNotFoundException("Member")
+        val member = getMember(request.memberId)
 
+        // 질문 대상(튜터)을 옳게 설정했는지 확인
+        validateAvailableTutor(request.tutorId)
         // 질문은 학생만 할 수 있다
-        member.validateRole("STUDENT")
+        validateRole(member.role)
 
         val question = request.to(member)
         member.addQuestion(question)
@@ -32,16 +36,15 @@ class QuestionService(
 
     @Transactional
     fun updateQuestion(questionId: Long, request: UpdateQuestionRequest) {
-        val member = memberRepository.findByIdOrNull(request.memberId)
-            ?: throw ModelNotFoundException("Member")
-        val question = questionRepository.findByIdOrNull(questionId)
-            ?: throw ModelNotFoundException("Question")
-        if (!memberRepository.existsById(request.tutorId)) throw ModelNotFoundException("Member")
+        val member = getMember(request.memberId)
+        val question = getQuestion(questionId)
 
+        // 질문 대상(튜터)을 옳게 설정했는지 확인
+        validateAvailableTutor(request.tutorId)
         // 질문 수정은 학생만 할 수 있다
-        member.validateRole("STUDENT")
+        validateRole(member.role)
         // 질문에 답변이 1개 이상 존재하는 경우, 학생은 질문을 수정할 수 없다
-        question.availableToUpdate()
+        validateAvailabilityToUpdate(question)
 
         member.removeQuestion(question)
         question.update(request.title, request.content, request.isPrivate)
@@ -52,15 +55,31 @@ class QuestionService(
 
     @Transactional
     fun deleteQuestion(memberId: Long, questionId: Long) {
-        val member = memberRepository.findByIdOrNull(memberId)
-            ?: throw ModelNotFoundException("Member")
-        val question = questionRepository.findByIdOrNull(questionId)
-            ?: throw ModelNotFoundException("Question")
+        val member = getMember(memberId)
+        val question = getQuestion(questionId)
 
         // 질문 삭제는 학생만 할 수 있다
-        member.validateRole("STUDENT")
+        validateRole(member.role)
 
         member.removeQuestion(question)
         questionRepository.delete(question)
+    }
+
+    private fun getMember(memberId: Long) =
+        memberRepository.findByIdOrNull(memberId) ?: throw ModelNotFoundException("Member")
+
+    private fun getQuestion(questionId: Long) =
+        questionRepository.findByIdOrNull(questionId) ?: throw ModelNotFoundException("Question")
+
+    private fun validateRole(role: MemberRole) {
+        if (MemberRole.isTutor(role)) throw WrongRoleException(role.name)
+    }
+
+    private fun validateAvailabilityToUpdate(question: Question) {
+        if (question.answers.isNotEmpty()) throw AlreadyHaveAnswersException()
+    }
+
+    private fun validateAvailableTutor(tutorId: Long){
+        if (!memberRepository.existsById(tutorId)) throw ModelNotFoundException("Member")
     }
 }

--- a/src/main/kotlin/com/sparta/tfbq/domain/question/service/QuestionService.kt
+++ b/src/main/kotlin/com/sparta/tfbq/domain/question/service/QuestionService.kt
@@ -58,6 +58,14 @@ class QuestionService(
         val member = getMember(memberId)
         val question = getQuestion(questionId)
 
+        /*
+        memberId로 member를 가져오면?
+        '삭제' 버튼을 누른 사람
+
+        questionId->question->member->id로 member를 가져오면?
+        질문 등록한 사람
+         */
+
         // 질문 삭제는 학생만 할 수 있다
         validateRole(member.role)
 

--- a/src/test/kotlin/com/sparta/tfbq/domain/question/service/QuestionServiceTest.kt
+++ b/src/test/kotlin/com/sparta/tfbq/domain/question/service/QuestionServiceTest.kt
@@ -77,7 +77,7 @@ class QuestionServiceTest {
         val question = questionRepository.findByIdOrNull(1L) ?: throw ModelNotFoundException("")
 
         // when (정상 처리)
-        val updateRequest = UpdateQuestionRequest(student.id!!, tutor.id!!, "수정된 제목 예시", "수정된 내용 예시", true)
+        val updateRequest = UpdateQuestionRequest(student.id!!,"수정된 제목 예시", "수정된 내용 예시", true)
         service.updateQuestion(question.id!!, updateRequest)
 
         // then (정상 처리)


### PR DESCRIPTION
## 연관 이슈
- closes #25 

## 해당 작업을 한 동기는 무엇인가요?
- 질문 도메인 관련 클래스 코드 리팩토링

## 리뷰어에게 작업 또는 변경 내용을 가능한 상세히 설명해주세요
- [ ] QuestionService 내 반복되는 코드를 내부 메서드로 분리
  - getMember, getQuestion, validateRole, validateAvailabilityToUpdate, validateAvailableTutor
- [ ] QuestionController의 deleteQuestion의 mapping URI 수정
  - 기존: /{memberId}/{questionId} ---> 수정 : /{questionId}/{memberId}
- [ ] QuestionController 내 들여쓰기 조정
- [ ] QuestionService 내 불필요한 주석 삭제
