### PR TITLE
Feat/#35 로그인 기능 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,114 @@
-# think-first-before-question
-[물어보기 전에 생각했나요?] - 튜터 학생 간 질문 커뮤니티
+# 물어보기 전에 생각했나요? - 튜터 학생 간 질문 커뮤니티
+
+## 🤓 프로젝트 설명
+
+스파르타코딩클럽의 부트캠프에 참여하는 모든 학생들이 학습 도중 모르는 문제에 직면했을 때 튜터님들에게 질문을 하고, 튜터님들은 해당 질문에 대한 답변을 등록하는 ‘질문-답변 게시판’ 을 제작하는 프로젝트입니다.
+
+
+## 🚀 개발 기간
+
+`2024-01-08` ~ `2024-01-15`
+
+## 🤼 개발 인원
+
+| 백승한                                                       | 허훈                                                      | 이인재                                                        | 박지영                                                        |
+|-----------------------------------------------------------|---------------------------------------------------------|------------------------------------------------------------|------------------------------------------------------------|
+| ![](https://avatars.githubusercontent.com/u/84169773?v=4) | ![](https://avatars.githubusercontent.com/u/152062846?v=4) | ![](https://avatars.githubusercontent.com/u/152145394?v=4) | ![](https://avatars.githubusercontent.com/u/152155627?v=4) |
+| [@back-seung](https://github.com/back-seung)              | [@hunzzzzz](https://github.com/hunzzzzz)                | [@distecter](https://github.com/distecter/distecter)       | [@jiyeong2023](https://github.com/jiyeong2023)             |
+| `팀 리드`, `전체 기능 리팩터링`, `버그 픽스`, `팀 컨벤션 관리`                 | `질문 & 답변 CRUD`, `버그 픽스`                                 | `멤버 CRUD`                                                    | `멤버 CRUD`                                                    |
+
+## 🛠️ 개발 도구 및 환경
+<img src="https://img.shields.io/badge/Kotlin-7F52FF?style=for-the-badge&logo=kotlin&logoColor=white">
+<img src="https://img.shields.io/badge/Spring Boot-6DB33F?style=for-the-badge&logo=springboot&logoColor=white">
+<img src="https://img.shields.io/badge/Spring Data Jpa-6DB33F?style=for-the-badge&logo=spring&logoColor=white">
+<img src="https://img.shields.io/badge/Swagger-6DB33F?style=for-the-badge&logo=swagger&logoColor=white">
+<img src="https://img.shields.io/badge/postgresql-151F5D?style=for-the-badge&logo=postgresql&logoColor=white">
+<img src="https://img.shields.io/badge/IntelliJ Ultimate Idea-000000?style=for-the-badge&logo=intellijidea&logoColor=white">
+
+
+## 🗺️ 프로젝트 패키지 구조
+
+```markdown
+├── README.md
+├── .github
+│   ├── ISSUE-TEMPLATE
+│   └── PULL_REQUEST_TEMPLATE
+├── .gitignore
+├── .build.gradle.kts
+├── .idea
+├── .gradle
+└── src.main.kotlin
+    └── com.sparta.tfbq
+        ├── domain
+        │   ├── answer
+        │   │   ├── controller
+        │   │   ├── dto
+        │   │   │   ├── request
+        │   │   │   └── response
+        │   │   ├── model
+        │   │   ├── repository
+        │   │   └── service
+        │   ├── member
+        │   │   ├── common
+        │   │   │   ├── controller
+        │   │   │   └── service
+        │   │   ├── domain
+        │   │   │   ├── student
+        │   │   │   │   ├── controller
+        │   │   │   │   ├── dto
+        │   │   │   │   │ ├── request
+        │   │   │   │   │ └── response
+        │   │   │   │   └── service
+        │   │   │   └── tutor
+        │   │   │   ├── controller
+        │   │   │   ├── dto
+        │   │   │   │   ├── request
+        │   │   │   │   └── response
+        │   │   │   └── service
+        │   │   ├── exception
+        │   │   ├── model
+        │   │   ├── repository
+        │   │   └── Member.kt
+        │   └── question
+        │   ├── controller
+        │   ├── dto
+        │   │   ├── request
+        │   │   └── response
+        │   ├── model
+        │   ├── repository
+        │   └── service
+        └── global
+                ├── config
+                ├── entity
+                ├── exception
+                ├── infra
+                │   └── swagger
+                └── util
+```
+
+## 🤝 팀 컨벤션
+> 커밋, 이슈, PR 등록시 공통 컨벤션을 지정했습니다.
+> - [이슈 템플릿](https://github.com/team-sparta-a01-team-pr/think-first-before-question/tree/dev/.github/ISSUE_TEMPLATE)
+> - [PR 템플릿](https://github.com/team-sparta-a01-team-pr/think-first-before-question/blob/dev/.github/PULL_REQUEST_TEMPLATE.md)
+###  Issue / PR / 커밋 등록 시 제목 공통 Prefix
+```markdown
+- ✨ feat: 새로운 기능을 추가한 경우
+- 🐛 bugfix: 올바르지 않은 동작(버그)을 고친 경우
+- 📝 add: feat 이외의 부수적인 코드, 라이브러리 등을 추가한 경우, 새로운 파일(Component나 Activity 등)을 생성한 경우도 포함
+- ♻️ refactor: 내부 로직은 변경하지 않고 기존의 코드를 개선한 경우, 클래스명 수정&가독성을 위해 변수명을 변경한 경우도 포함
+- 🔥 remove: 코드, 파일을 삭제한 경우, 필요 없는 주석 삭제도 포함
+- 📝 docs: 문서를 추가, 수정한 경우
+- ✅ test: 테스트 코드를 추가, 수정, 삭제한 경우
+```
+
+### 커밋 컨벤션
+```markdown
+Feat: 제목 작성 (1줄 이내 작성)
+(공백)
+공백 이하 본문 작성 (본문 10줄 이내 작성)
+- 작업 내용 간단 요약 1
+- 작업 내용 간단 요약 2
+- 작업 내용 간단 요약 3
+- 작업 내용 간단 요약 4
+- 작업 내용 간단 요약 5
+```

--- a/src/main/kotlin/com/sparta/tfbq/auth/controller/AuthContoller.kt
+++ b/src/main/kotlin/com/sparta/tfbq/auth/controller/AuthContoller.kt
@@ -1,0 +1,27 @@
+package com.sparta.tfbq.auth.controller
+
+import com.sparta.tfbq.auth.dto.request.MemberLoginRequest
+import com.sparta.tfbq.auth.dto.request.TokenRefreshRequest
+import com.sparta.tfbq.auth.dto.response.JwtResponse
+import com.sparta.tfbq.auth.service.AuthService
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/api/v1/auth")
+class AuthController(
+    private val authService: AuthService
+) {
+
+    @PostMapping("/login")
+    fun login(@RequestBody request: MemberLoginRequest): ResponseEntity<Unit> {
+        return ResponseEntity.ok().build()
+    }
+
+    @PostMapping("/refreshtoken")
+    fun refreshToken(@RequestBody request: TokenRefreshRequest): ResponseEntity<JwtResponse> {
+        authService.refreshToken(request)
+            .let { return ResponseEntity.ok(it) }
+    }
+
+}

--- a/src/main/kotlin/com/sparta/tfbq/auth/dto/request/MemberLoginRequest.kt
+++ b/src/main/kotlin/com/sparta/tfbq/auth/dto/request/MemberLoginRequest.kt
@@ -1,0 +1,6 @@
+package com.sparta.tfbq.auth.dto.request
+
+data class MemberLoginRequest(
+    val email: String,
+    val password: String
+)

--- a/src/main/kotlin/com/sparta/tfbq/auth/dto/request/TokenRefreshRequest.kt
+++ b/src/main/kotlin/com/sparta/tfbq/auth/dto/request/TokenRefreshRequest.kt
@@ -1,0 +1,5 @@
+package com.sparta.tfbq.auth.dto.request
+
+data class TokenRefreshRequest(
+    val refreshToken: String
+)

--- a/src/main/kotlin/com/sparta/tfbq/auth/dto/response/JwtResponse.kt
+++ b/src/main/kotlin/com/sparta/tfbq/auth/dto/response/JwtResponse.kt
@@ -1,0 +1,6 @@
+package com.sparta.tfbq.auth.dto.response
+
+data class JwtResponse(
+    val accessToken: String,
+    val refreshToken: String
+)

--- a/src/main/kotlin/com/sparta/tfbq/auth/filter/AuthRequestWrapper.kt
+++ b/src/main/kotlin/com/sparta/tfbq/auth/filter/AuthRequestWrapper.kt
@@ -1,0 +1,59 @@
+package com.sparta.tfbq.auth.filter
+
+import io.micrometer.common.util.StringUtils
+import jakarta.servlet.ReadListener
+import jakarta.servlet.ServletInputStream
+import jakarta.servlet.ServletRequest
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletRequestWrapper
+import java.io.BufferedReader
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.InputStreamReader
+import java.nio.charset.Charset
+import java.nio.charset.StandardCharsets
+
+class AuthRequestWrapper(request: HttpServletRequest) : HttpServletRequestWrapper(request) {
+    private val encoding: Charset
+    private val rawData: ByteArray
+
+    init {
+        var characterEncoding = request.characterEncoding
+        if (StringUtils.isBlank(characterEncoding)) {
+            characterEncoding = StandardCharsets.UTF_8.name()
+        }
+
+        this.encoding = Charset.forName(characterEncoding)
+
+        val inputStream = request.inputStream
+        val buffer = ByteArray(1024)
+        val byteArrayOutputStream = ByteArrayOutputStream()
+        var bytesRead: Int
+        while (inputStream.read(buffer).also { bytesRead = it } != -1) {
+            byteArrayOutputStream.write(buffer, 0, bytesRead)
+        }
+
+        this.rawData = byteArrayOutputStream.toByteArray()
+    }
+
+    override fun getInputStream(): ServletInputStream {
+        val byteArrayInputStream = ByteArrayInputStream(this.rawData)
+        return object : ServletInputStream() {
+
+            override fun read() = byteArrayInputStream.read()
+
+            override fun isFinished() = false
+
+            override fun isReady() = false
+
+            override fun setReadListener(listener: ReadListener?) {
+
+            }
+
+        }
+    }
+
+    override fun getReader() = BufferedReader(InputStreamReader(this.inputStream, this.encoding))
+    override fun getRequest(): ServletRequest = super.getRequest()
+
+}

--- a/src/main/kotlin/com/sparta/tfbq/auth/filter/JwtFilter.kt
+++ b/src/main/kotlin/com/sparta/tfbq/auth/filter/JwtFilter.kt
@@ -1,0 +1,29 @@
+package com.sparta.tfbq.auth.filter
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.sparta.tfbq.auth.model.AUTHENTICATE_MEMBER
+import com.sparta.tfbq.auth.model.AuthenticatedMember
+import com.sparta.tfbq.global.auth.JwtUtil.createJwt
+import jakarta.servlet.Filter
+import jakarta.servlet.FilterChain
+import jakarta.servlet.ServletRequest
+import jakarta.servlet.ServletResponse
+import org.springframework.stereotype.Component
+
+@Component
+class JwtFilter(
+    private val objectMapper: ObjectMapper,
+) : Filter {
+    override fun doFilter(request: ServletRequest?, response: ServletResponse?, chain: FilterChain?) {
+        (request?.getAttribute(AUTHENTICATE_MEMBER) as AuthenticatedMember)
+            .let { objectMapper.writeValueAsString(it) }
+            .let { mutableMapOf<String, Any>(AUTHENTICATE_MEMBER to it) }
+            .let { objectMapper.writeValueAsString(createJwt(it)) }
+            .let {
+                response?.contentType = "application/json"
+                response?.characterEncoding = "UTF-8"
+                response?.writer?.write(it)
+            }
+        chain?.doFilter(request, response)
+    }
+}

--- a/src/main/kotlin/com/sparta/tfbq/auth/filter/VerifyMemberFilter.kt
+++ b/src/main/kotlin/com/sparta/tfbq/auth/filter/VerifyMemberFilter.kt
@@ -1,0 +1,33 @@
+package com.sparta.tfbq.auth.filter
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.sparta.tfbq.auth.dto.request.MemberLoginRequest
+import com.sparta.tfbq.auth.model.AUTHENTICATE_MEMBER
+import com.sparta.tfbq.auth.model.AuthenticatedMember
+import com.sparta.tfbq.auth.service.AuthService
+import jakarta.servlet.Filter
+import jakarta.servlet.FilterChain
+import jakarta.servlet.ServletRequest
+import jakarta.servlet.ServletResponse
+import jakarta.servlet.http.HttpServletRequest
+import org.springframework.stereotype.Component
+
+@Component
+class VerifyMemberFilter(
+    private val objectMapper: ObjectMapper,
+    private val authService: AuthService
+): Filter {
+    override fun doFilter(request: ServletRequest?, response: ServletResponse?, chain: FilterChain?) {
+        val httpServletRequest = (request as HttpServletRequest)
+        if (httpServletRequest.method == "POST") {
+            val requestWrapper = AuthRequestWrapper(request)
+            httpServletRequest
+                .let { objectMapper.readValue(requestWrapper.reader, MemberLoginRequest::class.java) }
+                .let { authService.verifyMember(it) }
+                .let { AuthenticatedMember(it.email, it.role.name) }
+                .let { requestWrapper.setAttribute(AUTHENTICATE_MEMBER, it) }
+
+            chain?.doFilter(requestWrapper, response)
+        }
+    }
+}

--- a/src/main/kotlin/com/sparta/tfbq/auth/model/AuthenticatedMember.kt
+++ b/src/main/kotlin/com/sparta/tfbq/auth/model/AuthenticatedMember.kt
@@ -1,0 +1,8 @@
+package com.sparta.tfbq.auth.model
+
+const val AUTHENTICATE_MEMBER = "authenticated"
+
+class AuthenticatedMember(
+    val email: String,
+    val role: String
+)

--- a/src/main/kotlin/com/sparta/tfbq/auth/service/AuthService.kt
+++ b/src/main/kotlin/com/sparta/tfbq/auth/service/AuthService.kt
@@ -1,0 +1,36 @@
+package com.sparta.tfbq.auth.service
+
+import com.sparta.tfbq.auth.dto.request.MemberLoginRequest
+import com.sparta.tfbq.auth.dto.request.TokenRefreshRequest
+import com.sparta.tfbq.auth.dto.response.JwtResponse
+import com.sparta.tfbq.domain.member.Member
+import com.sparta.tfbq.domain.member.repository.MemberRepository
+import com.sparta.tfbq.global.auth.JwtUtil.createJwt
+import com.sparta.tfbq.global.auth.JwtUtil.getClaims
+import com.sparta.tfbq.global.util.PasswordEncoder.encode
+import org.springframework.stereotype.Service
+
+@Service
+class AuthService(
+    private val memberRepository: MemberRepository
+) {
+
+    fun refreshToken(request: TokenRefreshRequest): JwtResponse {
+        val member = verifyMember(request.refreshToken)
+        val claims = getClaims(request.refreshToken)
+        val jwt = createJwt(claims)
+        member.updateRefreshToken(jwt.refreshToken)
+
+        return jwt
+    }
+
+    private fun verifyMember(refreshToken: String): Member {
+        return memberRepository.findByRefreshToken(refreshToken) ?: throw RuntimeException()
+    }
+
+    fun verifyMember(request: MemberLoginRequest): Member {
+        return memberRepository.findByEmailAndPassword(request.email, encode(request.password))
+            ?: throw RuntimeException()
+    }
+
+}

--- a/src/main/kotlin/com/sparta/tfbq/domain/member/Member.kt
+++ b/src/main/kotlin/com/sparta/tfbq/domain/member/Member.kt
@@ -3,7 +3,7 @@ package com.sparta.tfbq.domain.member
 import com.sparta.tfbq.domain.member.model.MemberRole
 import com.sparta.tfbq.domain.question.model.Question
 import com.sparta.tfbq.global.entity.BaseEntity
-import com.sparta.tfbq.global.util.PasswordEncoder.Companion.encode
+import com.sparta.tfbq.global.util.PasswordEncoder.encode
 import jakarta.persistence.*
 
 @Entity
@@ -45,4 +45,11 @@ class Member(
     var password = encode(password)
         private set
 
+    @Column(name = "refresh_token")
+    var refreshToken: String? = null
+        private set
+
+    fun updateRefreshToken(refreshToken: String) {
+        this.refreshToken = refreshToken
+    }
 }

--- a/src/main/kotlin/com/sparta/tfbq/domain/member/repository/MemberRepository.kt
+++ b/src/main/kotlin/com/sparta/tfbq/domain/member/repository/MemberRepository.kt
@@ -8,5 +8,6 @@ import org.springframework.stereotype.Repository
 interface MemberRepository : JpaRepository<Member, Long> {
     fun existsByEmail(email: String): Boolean
     fun existsByNickname(nickname: String): Boolean
-    fun existsEmailAndPassword(name: String, password: String): Boolean
+    fun findByEmailAndPassword(name: String, password: String): Member?
+    fun findByRefreshToken(refreshToken: String): Member?
 }

--- a/src/main/kotlin/com/sparta/tfbq/global/auth/JwtUtil.kt
+++ b/src/main/kotlin/com/sparta/tfbq/global/auth/JwtUtil.kt
@@ -1,0 +1,49 @@
+package com.sparta.tfbq.global.auth
+
+import com.sparta.tfbq.auth.dto.response.JwtResponse
+import io.jsonwebtoken.Claims
+import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.security.Keys
+import java.util.*
+
+object JwtUtil {
+
+    private const val SECRET = "5v87n5ytf9c9wn9yfco8w7adh8whonca8f87"
+
+    private val key = Keys.hmacShaKeyFor(SECRET.toByteArray())
+
+    fun createJwt(claims: Map<String, Any>): JwtResponse {
+        val accessToken = createToken(claims, getExpireDateOfAccessToken())
+        val refreshToken = createToken(emptyMap(), getExpireDateOfRefreshToken())
+
+        return JwtResponse(accessToken, refreshToken)
+    }
+
+    private fun createToken(claims: Map<String, Any>, expireDate: Date): String {
+        return Jwts.builder()
+            .setSubject(claims["email"].toString())
+            .addClaims(claims)
+            .setExpiration(expireDate)
+            .signWith(key)
+            .compact()
+    }
+
+    fun getClaims(refreshToken: String): Claims {
+        return Jwts.parserBuilder()
+            .setSigningKey(key)
+            .build()
+            .parseClaimsJws(refreshToken)
+            .body
+    }
+
+    private fun getExpireDateOfAccessToken(): Date {
+        val expireTimeMils = 1000 * 60 * 60
+        return Date(System.currentTimeMillis() + expireTimeMils)
+    }
+
+    private fun getExpireDateOfRefreshToken(): Date {
+        val expireTimeMils = 1000L * 60 * 60 * 24
+        return Date(System.currentTimeMillis() + expireTimeMils)
+    }
+
+}

--- a/src/main/kotlin/com/sparta/tfbq/global/config/SwaggerConfig.kt
+++ b/src/main/kotlin/com/sparta/tfbq/global/config/SwaggerConfig.kt
@@ -1,4 +1,4 @@
-package com.sparta.tfbq.global.infra.swagger
+package com.sparta.tfbq.global.config
 
 import io.swagger.v3.oas.models.Components
 import io.swagger.v3.oas.models.OpenAPI

--- a/src/main/kotlin/com/sparta/tfbq/global/config/WebContextConfig.kt
+++ b/src/main/kotlin/com/sparta/tfbq/global/config/WebContextConfig.kt
@@ -1,0 +1,35 @@
+package com.sparta.tfbq.global.config
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.sparta.tfbq.auth.filter.JwtFilter
+import com.sparta.tfbq.auth.filter.VerifyMemberFilter
+import com.sparta.tfbq.auth.service.AuthService
+import jakarta.servlet.Filter
+import org.springframework.boot.web.servlet.FilterRegistrationBean
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class WebContextConfig {
+
+    @Bean
+    fun verifyMemberFilter(
+        objectMapper: ObjectMapper,
+        authService: AuthService
+    ): FilterRegistrationBean<Filter> {
+        val filterRegistrationBean = FilterRegistrationBean<Filter>()
+        filterRegistrationBean.filter = VerifyMemberFilter(objectMapper, authService)
+        filterRegistrationBean.order = 1
+        filterRegistrationBean.urlPatterns = listOf("/api/v1/auth/login")
+        return filterRegistrationBean
+    }
+
+    @Bean
+    fun jwtFilter(objectMapper: ObjectMapper): FilterRegistrationBean<Filter> {
+        val filterRegistrationBean = FilterRegistrationBean<Filter>()
+        filterRegistrationBean.filter = JwtFilter(objectMapper)
+        filterRegistrationBean.order = 2
+        filterRegistrationBean.urlPatterns = listOf("/api/v1/auth/login")
+        return filterRegistrationBean
+    }
+}

--- a/src/main/kotlin/com/sparta/tfbq/global/util/PasswordEncoder.kt
+++ b/src/main/kotlin/com/sparta/tfbq/global/util/PasswordEncoder.kt
@@ -2,13 +2,11 @@ package com.sparta.tfbq.global.util
 
 import java.util.Base64
 
-class PasswordEncoder {
-    companion object {
+object PasswordEncoder {
 
-        fun encode(password: String) = Base64.getEncoder().encodeToString(password.toByteArray())!!
+    fun encode(password: String) = Base64.getEncoder().encodeToString(password.toByteArray())!!
 
-        fun decode(encodedPassword: String) = Base64.getEncoder()
-            .encodeToString(encodedPassword.toByteArray())!!
+    fun decode(encodedPassword: String) = Base64.getEncoder()
+        .encodeToString(encodedPassword.toByteArray())!!
 
-    }
 }


### PR DESCRIPTION
## 연관 이슈
- closes #35 

## 해당 작업을 한 동기는 무엇인가요?
- 추가 구현 중 인증/인가를 구현하기 위해 로그인 기능을 추가 했습니다. 로그인을 하는 유저는 1차적으로 검증을 하는 Filter에서 검증하고, 2차로  검증된 유저에게 토큰을 발급하는 Filter를 만들어 리프레시 토큰을 서버에 저장하여 관리하고, 만료 시에는 리프레시토큰을 통해 재발급이 가능하도록 설계하였으며, Filter와 Jwt를 사용하여 이를 구현하였습니다.

## 리뷰어에게 작업 또는 변경 내용을 가능한 상세히 설명해주세요
- [ ] 누락된 내용이 있거나, 추가로 구현을 고민해봐야 하는 내용을 말씀해주시면 좋겠습니다 👍 !!
