### PR TITLE
Bugfix/#39 로그인 기능 버그 수정

### DIFF
--- a/src/main/kotlin/com/sparta/tfbq/auth/filter/JwtFilter.kt
+++ b/src/main/kotlin/com/sparta/tfbq/auth/filter/JwtFilter.kt
@@ -3,6 +3,7 @@ package com.sparta.tfbq.auth.filter
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.sparta.tfbq.auth.model.AUTHENTICATE_MEMBER
 import com.sparta.tfbq.auth.model.AuthenticatedMember
+import com.sparta.tfbq.auth.service.AuthService
 import com.sparta.tfbq.global.auth.JwtUtil.createJwt
 import jakarta.servlet.Filter
 import jakarta.servlet.FilterChain
@@ -13,12 +14,17 @@ import org.springframework.stereotype.Component
 @Component
 class JwtFilter(
     private val objectMapper: ObjectMapper,
+    private val authService: AuthService,
 ) : Filter {
     override fun doFilter(request: ServletRequest?, response: ServletResponse?, chain: FilterChain?) {
         (request?.getAttribute(AUTHENTICATE_MEMBER) as AuthenticatedMember)
             .let { objectMapper.writeValueAsString(it) }
             .let { mutableMapOf<String, Any>(AUTHENTICATE_MEMBER to it) }
-            .let { objectMapper.writeValueAsString(createJwt(it)) }
+            .let { createJwt(it) }
+            .let {
+                authService.saveRefreshToken(it)
+                objectMapper.writeValueAsString(it)
+            }
             .let {
                 response?.contentType = "application/json"
                 response?.characterEncoding = "UTF-8"

--- a/src/main/kotlin/com/sparta/tfbq/auth/service/AuthService.kt
+++ b/src/main/kotlin/com/sparta/tfbq/auth/service/AuthService.kt
@@ -7,6 +7,7 @@ import com.sparta.tfbq.domain.member.Member
 import com.sparta.tfbq.domain.member.repository.MemberRepository
 import com.sparta.tfbq.global.auth.JwtUtil.createJwt
 import com.sparta.tfbq.global.auth.JwtUtil.getClaims
+import com.sparta.tfbq.global.exception.ModelNotFoundException
 import com.sparta.tfbq.global.util.PasswordEncoder.encode
 import org.springframework.stereotype.Service
 
@@ -14,6 +15,11 @@ import org.springframework.stereotype.Service
 class AuthService(
     private val memberRepository: MemberRepository
 ) {
+
+    fun saveRefreshToken(jwt: JwtResponse) {
+        val member = getMemberByEmail(getClaims(jwt.accessToken)["email"] as String)
+        member.updateRefreshToken(jwt.refreshToken)
+    }
 
     fun refreshToken(request: TokenRefreshRequest): JwtResponse {
         val member = verifyMember(request.refreshToken)
@@ -31,6 +37,10 @@ class AuthService(
     fun verifyMember(request: MemberLoginRequest): Member {
         return memberRepository.findByEmailAndPassword(request.email, encode(request.password))
             ?: throw RuntimeException()
+    }
+
+    fun getMemberByEmail(email: String): Member {
+        return memberRepository.findByEmail(email) ?: throw ModelNotFoundException("Member")
     }
 
 }

--- a/src/main/kotlin/com/sparta/tfbq/domain/member/repository/MemberRepository.kt
+++ b/src/main/kotlin/com/sparta/tfbq/domain/member/repository/MemberRepository.kt
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Repository
 
 @Repository
 interface MemberRepository : JpaRepository<Member, Long> {
+    fun findByEmail(email: String): Member?
     fun existsByEmail(email: String): Boolean
     fun existsByNickname(nickname: String): Boolean
     fun findByEmailAndPassword(name: String, password: String): Member?

--- a/src/main/kotlin/com/sparta/tfbq/global/config/WebContextConfig.kt
+++ b/src/main/kotlin/com/sparta/tfbq/global/config/WebContextConfig.kt
@@ -25,9 +25,12 @@ class WebContextConfig {
     }
 
     @Bean
-    fun jwtFilter(objectMapper: ObjectMapper): FilterRegistrationBean<Filter> {
+    fun jwtFilter(
+        objectMapper: ObjectMapper,
+        authService: AuthService
+    ): FilterRegistrationBean<Filter> {
         val filterRegistrationBean = FilterRegistrationBean<Filter>()
-        filterRegistrationBean.filter = JwtFilter(objectMapper)
+        filterRegistrationBean.filter = JwtFilter(objectMapper, authService)
         filterRegistrationBean.order = 2
         filterRegistrationBean.urlPatterns = listOf("/api/v1/auth/login")
         return filterRegistrationBean


### PR DESCRIPTION
## 연관 이슈
- closes #36 
- closes #39 

## 해당 작업을 한 동기는 무엇인가요?
- 기존 로그인 방법으로 로그인시, 리프레시 토큰이 저장되지 않는 이슈가 있어 이를 추가하였고, 추후에는 최초 로그인시에만 저장하게 하고, 그 다음부터는 만료일이 얼마 남지 않은 경우에만 재발급 하는 로직으로 수정해야 할 것 같습니다.

## 리뷰어에게 작업 또는 변경 내용을 가능한 상세히 설명해주세요
- [ ] AuthService 리프레시 토큰 저장 메서드 작성
- [ ] JwtFilter 의존 추가 및 AuthService 리프레시 토큰 저장 메서드 호출 로직 추가
- [ ] MemberRepository 이메일 기반 멤버 조회 JPA 메서드 추가
