### PR TITLE
Bugfix: 로그인 기능 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,6 +43,7 @@ dependencies {
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     // DB
     runtimeOnly("com.h2database:h2")
+    runtimeOnly("org.postgresql:postgresql")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     // VALIDATION
     implementation("org.springframework.boot:spring-boot-starter-validation")

--- a/src/main/kotlin/com/sparta/tfbq/auth/model/AuthenticatedMember.kt
+++ b/src/main/kotlin/com/sparta/tfbq/auth/model/AuthenticatedMember.kt
@@ -1,8 +1,10 @@
 package com.sparta.tfbq.auth.model
 
+import com.fasterxml.jackson.annotation.JsonProperty
+
 const val AUTHENTICATE_MEMBER = "authenticated"
 
-class AuthenticatedMember(
-    val email: String,
-    val role: String
+data class AuthenticatedMember(
+    @JsonProperty("email") val email: String,
+    @JsonProperty("role") val role: String
 )

--- a/src/main/kotlin/com/sparta/tfbq/auth/service/AuthService.kt
+++ b/src/main/kotlin/com/sparta/tfbq/auth/service/AuthService.kt
@@ -6,9 +6,11 @@ import com.sparta.tfbq.auth.dto.response.JwtResponse
 import com.sparta.tfbq.domain.member.Member
 import com.sparta.tfbq.domain.member.repository.MemberRepository
 import com.sparta.tfbq.global.auth.JwtUtil.createJwt
+import com.sparta.tfbq.global.auth.JwtUtil.getAuthenticateMember
 import com.sparta.tfbq.global.auth.JwtUtil.getClaims
 import com.sparta.tfbq.global.exception.ModelNotFoundException
 import com.sparta.tfbq.global.util.PasswordEncoder.encode
+import jakarta.transaction.Transactional
 import org.springframework.stereotype.Service
 
 @Service
@@ -16,11 +18,14 @@ class AuthService(
     private val memberRepository: MemberRepository
 ) {
 
+    @Transactional
     fun saveRefreshToken(jwt: JwtResponse) {
-        val member = getMemberByEmail(getClaims(jwt.accessToken)["email"] as String)
+        val authenticateMember = getAuthenticateMember(jwt.accessToken)
+        val member = getMemberByEmail(authenticateMember.email)
         member.updateRefreshToken(jwt.refreshToken)
     }
 
+    @Transactional
     fun refreshToken(request: TokenRefreshRequest): JwtResponse {
         val member = verifyMember(request.refreshToken)
         val claims = getClaims(request.refreshToken)

--- a/src/main/kotlin/com/sparta/tfbq/global/auth/JwtUtil.kt
+++ b/src/main/kotlin/com/sparta/tfbq/global/auth/JwtUtil.kt
@@ -1,16 +1,19 @@
 package com.sparta.tfbq.global.auth
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.sparta.tfbq.auth.dto.response.JwtResponse
+import com.sparta.tfbq.auth.model.AUTHENTICATE_MEMBER
+import com.sparta.tfbq.auth.model.AuthenticatedMember
 import io.jsonwebtoken.Claims
 import io.jsonwebtoken.Jwts
 import io.jsonwebtoken.security.Keys
 import java.util.*
 
 object JwtUtil {
-
     private const val SECRET = "5v87n5ytf9c9wn9yfco8w7adh8whonca8f87"
 
     private val key = Keys.hmacShaKeyFor(SECRET.toByteArray())
+    private val objectMapper = ObjectMapper()
 
     fun createJwt(claims: Map<String, Any>): JwtResponse {
         val accessToken = createToken(claims, getExpireDateOfAccessToken())
@@ -34,6 +37,16 @@ object JwtUtil {
             .build()
             .parseClaimsJws(refreshToken)
             .body
+    }
+
+    fun getAuthenticateMember(accessToken: String): AuthenticatedMember {
+        val authenticateMemberJson = Jwts.parserBuilder()
+            .setSigningKey(key)
+            .build()
+            .parseClaimsJws(accessToken)
+            .body[AUTHENTICATE_MEMBER] as String
+
+        return objectMapper.readValue(authenticateMemberJson, AuthenticatedMember::class.java)
     }
 
     private fun getExpireDateOfAccessToken(): Date {


### PR DESCRIPTION
- Service @Transactional 어노테이션 누락 추가
- AuthenticatedMember 수정
  - json readValue 적용을 위해 @JsonProperty 어노테이션 추가
  - data class로 변경
- JwtUtil getAuthenticateMember 메서드 추가

## 연관 이슈
- closes #41 

## 해당 작업을 한 동기는 무엇인가요?
- JwtFilter에서 Claim를 Jwt에 넣는 방법과, 서비스 코드에서 Claims를 가져오는 방법이 서로 달라 예외가 발생하는 것을 확인 하였습니다.

## 리뷰어에게 작업 또는 변경 내용을 가능한 상세히 설명해주세요
- [x] JwtUtil 내에 getAuthenticatedMember 메서드를 생성하였습니다.
  - [x] accessToken으로 Claims를 꺼내고, Claims의 키값으로 얻은 json 값을 DTO로 변경합니다.
  - [x] DTO 변경을 위해 @JsonProperty를 추가하였고, 책임에 맞게 data 클래스로 변경하였습니다.
- [x] AuthService saveRefreshToken 메서드를 수정하였습니다.
